### PR TITLE
파일 조회 querydsl 생성 (수정)

### DIFF
--- a/src/main/java/org/teamproject/repositories/FileInfoRepository.java
+++ b/src/main/java/org/teamproject/repositories/FileInfoRepository.java
@@ -47,7 +47,7 @@ public interface FileInfoRepository extends JpaRepository<FileInfo, Long>, Query
 
     // gid 만 가지고 조회
     default List<FileInfo> getFiles(String gid) {
-        return getFiles(gid);
+        return getFiles(gid, null);
     }
 
     // 업로드 완료된 이후(Done이 붙은것으로 조회) 파일만 조회
@@ -56,6 +56,6 @@ public interface FileInfoRepository extends JpaRepository<FileInfo, Long>, Query
     }
 
     default List<FileInfo> getFilesDone(String gid) {
-        return getFiles(gid);
+        return getFiles(gid, null);
     }
 }


### PR DESCRIPTION
파일 조회 querydsl 생성 (수정)

gid에 location이 null값이 아니면 순환참조가 발생함.
null 추가 