### PR TITLE
파일 개별조회, 서버 경로, 파일 확장자, 파일 예외처리

### DIFF
--- a/src/main/java/org/teamproject/entities/FileInfo.java
+++ b/src/main/java/org/teamproject/entities/FileInfo.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -44,4 +45,10 @@ public class FileInfo extends BaseMemberEntity{ // 로그인 아이디 비교를
 
     @Transient
     private String fileUrl; //서버 접속 URL
+
+    @Transient
+    private List<String> thumbsPath; // 썸네일 이미지 경로
+
+    @Transient
+    private List<String> thumbsUrl; // 썸네일 이미지 접속 URL
 }

--- a/src/main/java/org/teamproject/models/member/files/FileDeleteService.java
+++ b/src/main/java/org/teamproject/models/member/files/FileDeleteService.java
@@ -1,0 +1,4 @@
+package org.teamproject.models.member.files;
+
+public class FileDeleteService {
+}

--- a/src/main/java/org/teamproject/models/member/files/FileDownloadService.java
+++ b/src/main/java/org/teamproject/models/member/files/FileDownloadService.java
@@ -1,0 +1,4 @@
+package org.teamproject.models.member.files;
+
+public class FileDownloadService {
+}

--- a/src/main/java/org/teamproject/models/member/files/FileInfoService.java
+++ b/src/main/java/org/teamproject/models/member/files/FileInfoService.java
@@ -1,0 +1,79 @@
+package org.teamproject.models.member.files;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.teamproject.entities.FileInfo;
+import org.teamproject.repositories.FileInfoRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileInfoService { // 파일 개별조회 목록조회 기능.
+
+    @Value("${file.upload.path}")
+    private String uploadPath;
+
+    @Value("file.upload.url")
+    private String uploadUrl;
+
+    private final HttpServletRequest request;
+
+    private final FileInfoRepository repository;
+
+    // 파일 등록 번호를 사용한 개별 조회
+    public FileInfo get(Long id) {
+
+        // 파일을 못찾을 시 예외 던짐.
+        FileInfo item = repository.findById(id).orElseThrow(FileNotFoundException::new);
+
+        addFileInfo(item);
+
+        return item;
+
+    }
+
+    public List<FileInfo> getList(Options opts) {
+
+
+        return null;
+    }
+
+    /**
+     * 파일 업로드 서버 경로(filePath)
+     * 파일 서버 접속 URL (fileUrl)
+     * 썸네일 경로 (thumbsPath), 썸네일 URL(thumbsUrl)
+     * */
+    public void addFileInfo(FileInfo item) {
+        long id = item.getId();
+        String extension = item.getExtension();
+
+        // 확장자 있을 경우 .확장자 , 없을경우 Id만.
+        String fileName = extension == null || extension.isBlank() ? "" + id : id + "." + extension;
+        long folder = id % 10L; // 각각 폴더 경로
+
+        // 파일 업로드 서버 경로
+        String filePath = uploadPath + "/" + folder + "/" + fileName;
+
+        // 파일 서버 접속 URL (fileUrl)
+        String fileUrl = request.getContextPath() + uploadUrl + folder + "/" + fileName;
+    }
+
+    @Data
+    @Builder
+    static class Options { // 여기서만 사용하므로 내부클래스 작성.
+        private String gid;
+        private String location;
+        private SearchMode mode = SearchMode.ALL;
+    }
+
+    static enum SearchMode {
+        ALL,
+        DONE,
+        UNDONE
+    }
+}

--- a/src/main/java/org/teamproject/models/member/files/FileNotFoundException.java
+++ b/src/main/java/org/teamproject/models/member/files/FileNotFoundException.java
@@ -1,0 +1,10 @@
+package org.teamproject.models.member.files;
+
+import org.springframework.http.HttpStatus;
+import org.teamproject.commons.CommonException;
+
+public class FileNotFoundException extends CommonException {
+    public FileNotFoundException() { // 파일 없을 시 발생.
+        super(bundleError.getString("NotFound.file"), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/teamproject/models/member/files/FileUploadService.java
+++ b/src/main/java/org/teamproject/models/member/files/FileUploadService.java
@@ -1,0 +1,4 @@
+package org.teamproject.models.member.files;
+
+public class FileUploadService {
+}

--- a/src/main/java/org/teamproject/repositories/FileInfoRepository.java
+++ b/src/main/java/org/teamproject/repositories/FileInfoRepository.java
@@ -35,7 +35,7 @@ public interface FileInfoRepository extends JpaRepository<FileInfo, Long>, Query
         if (mode.equals("done")) builder.and(fileInfo.done.eq(true));
         else if (mode.equals("undone")) builder.and(fileInfo.done.eq(false));
 
-        List<FileInfo> items = (List<FileInfo>)findAll(builder, Sort.by(Order.asc("createdBy")));
+        List<FileInfo> items = (List<FileInfo>)findAll(builder, Sort.by(Order.asc("createdAt")));
 
         return items;
     }
@@ -58,4 +58,15 @@ public interface FileInfoRepository extends JpaRepository<FileInfo, Long>, Query
     default List<FileInfo> getFilesDone(String gid) {
         return getFiles(gid, null);
     }
+
+    // 작업완료 처리
+    default void processDone(String gid) {
+        List<FileInfo> items = getFiles(gid);
+        items.stream().forEach(item -> {
+            item.setDone(true);
+        });
+
+        flush();
+    }
+    
 }

--- a/src/main/java/org/teamproject/repositories/FileInfoRepository.java
+++ b/src/main/java/org/teamproject/repositories/FileInfoRepository.java
@@ -68,5 +68,5 @@ public interface FileInfoRepository extends JpaRepository<FileInfo, Long>, Query
 
         flush();
     }
-    
+
 }


### PR DESCRIPTION
FileInfo 엔티티에 썸네일 경로 생성 

파일 등록 번호를 사용한 개별 조회

확장자 있을 경우 .확장자 , 없을 경우 Id만.

파일 업로드 서버 경로
파일 서버 접속 URL (fileUrl)

파일 없을 시 발행하는 예외.
- errors.properties 에 NotFound.file=등록되지 않은 파일입니다. 
- 